### PR TITLE
Multiple text are not translating (translate array of strings)

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -109,12 +109,16 @@ class Translator
 
         if (isset($parameters['text']) && is_array($parameters['text'])) {
             /*
-              https://tech.yandex.ru/translate/doc/dg/reference/translate-docpage/#param_text
-              Из документации: "В запросе можно использовать несколько параметров text"
-              Но Яндекс принимает именно несколько text=, а не PHP-интерпретацию в формате text[]=
+              https://tech.yandex.com/translate/doc/dg/reference/translate-docpage/#param_text (ENG)
+              https://tech.yandex.ru/translate/doc/dg/reference/translate-docpage/#param_text (RUS)
+              
+              According to documention: "You can use multiple text parameters in a request."
+              Yandex can receive only in format text=abc&text=def&text=klm&....&text=zzz
+              But PHP transform array to query string in format: text[1]=abc&text[2]=def&text[3]=klm&....&text[i]=zzz
+              For Yandex it is incorrect format of query string
              */
 
-            // ишем куски &text[индекс]= и меняем на просто &text=
+            // search substring "&text[index]=" and replace with "&text="
             $post = preg_replace('#(^|&)text%5B[0-9]+%5D=#', '$1text=', $post);
         }
 

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -104,8 +104,22 @@ class Translator
         $parameters['key'] = $this->key;
         curl_setopt($this->handler, CURLOPT_URL, static::BASE_URL . $uri);
         curl_setopt($this->handler, CURLOPT_POST, true);
-        curl_setopt($this->handler, CURLOPT_POSTFIELDS, http_build_query($parameters));
-        
+
+        $post = http_build_query($parameters);
+
+        if (isset($parameters['text']) && is_array($parameters['text'])) {
+            /*
+              https://tech.yandex.ru/translate/doc/dg/reference/translate-docpage/#param_text
+              Из документации: "В запросе можно использовать несколько параметров text"
+              Но Яндекс принимает именно несколько text=, а не PHP-интерпретацию в формате text[]=
+             */
+
+            // ишем куски &text[индекс]= и меняем на просто &text=
+            $post = preg_replace('#(^|&)text%5B[0-9]+%5D=#', '$1text=', $post);
+        }
+
+        curl_setopt($this->handler, CURLOPT_POSTFIELDS, $post);
+
         $remoteResult = curl_exec($this->handler);
         if ($remoteResult === false) {
             throw new Exception(curl_error($this->handler), curl_errno($this->handler));


### PR DESCRIPTION
https://tech.yandex.com/translate/doc/dg/reference/translate-docpage/#param_text (ENG)
https://tech.yandex.ru/translate/doc/dg/reference/translate-docpage/#param_text (RUS)

According to documention: "You can use multiple text parameters in a request."
Yandex can receive only in format text=abc&text=def&text=klm&....&text=zzz
But PHP transform array to query string in format: text[1]=abc&text[2]=def&text[3]=klm&....&text[i]=zzz
For Yandex it is incorrect format of query string

For example,
This [query](https://translate.yandex.net/api/v1.5/tr.json/translate?lang=en-ru&key=trnsl.1.1.20150823T221157Z.4a72fc749136d478.2fe9d4ab4de6b0eff82f15264b2ea7f59b049d19&text=Apple&text=Cherry&text=Blackberry) work fine.
But this [query](https://translate.yandex.net/api/v1.5/tr.json/translate?lang=en-ru&key=trnsl.1.1.20150823T221157Z.4a72fc749136d478.2fe9d4ab4de6b0eff82f15264b2ea7f59b049d19&text%5B0%5D=Apple&text%5B1%5D=Cherry&text%5B2%5D=Blackberry) not work.
Please pay attention, different of URL's only in param text=  and text[1]=
